### PR TITLE
Replace 'say' with 'echo' in error handling

### DIFF
--- a/src/install.sh.template
+++ b/src/install.sh.template
@@ -224,7 +224,7 @@ get_rid() {
 }
 
 err() {
-    say "$1" >&2
+    echo "$1" >&2
     exit 1
 }
 


### PR DESCRIPTION
From what I can tell, `say` is a MacOS-only text to speech tool, and it looks like this should use echo.